### PR TITLE
Support for STX (a 1024-byte YMODEM block) in CPython version

### DIFF
--- a/xoss_sync.py
+++ b/xoss_sync.py
@@ -160,7 +160,7 @@ class BluetoothFileTransfer:
             while self.idx_block_buf == 0:
                 await asyncio.sleep(0.01)
             if not self.is_block: return
-            block_size, self.block_data, self.block_crc = self.block_size_data_crc[int(self_block_buf[0] == _STX)]
+            block_size, self.block_data, self.block_crc = self.block_size_data_crc[int(self.block_buf[0] == _STX)]
             while self.idx_block_buf < block_size:
                 await asyncio.sleep(0.01)
 

--- a/xoss_sync.py
+++ b/xoss_sync.py
@@ -157,7 +157,7 @@ class BluetoothFileTransfer:
         #_SOH = VALUE_SOH[0] # SOH == 128-byte data
         _STX = VALUE_STX[0] # STX == 1024-byte data
         async def check_block_buf():
-            while self.idx_block_buf == 0:
+            while self.is_block and self.idx_block_buf == 0:
                 await asyncio.sleep(0.01)
             if not self.is_block: return
             block_size, self.block_data, self.block_crc = self.block_size_data_crc[int(self.block_buf[0] == _STX)]


### PR DESCRIPTION
Add support for STX blocks in YMODEM in CPython version.  This is not yet supported in MicroPython version.

Thanks to [Kaiserdragon2](https://github.com/Kaiserdragon2) for Issue #1.