### PR TITLE
Support for json list, fixes issue #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ D:\backup\Bicycle\XOSS\python>
 Though I tested this only with XOSS G+ (Gen1) and Windows10/11/Linux(BlueZ 5.56), combinations of the other XOSS device/OS may work. 
 For the other devices such as Cycplus, CooSpo and ROCKBROS, you may have to change the ```TARGET_NAME``` appropriately. 
 [Issue #1](https://github.com/ekspla/xoss_sync/issues/1) might be useful for Cycplus M2 users.
+On newer devices (e.g. XOSS NAV & G2+), the name of the track list has to be changed from ```filelist.txt``` to ```workouts.json```. 
 [Bleak](https://github.com/hbldh/bleak) supports Android, MacOS, Windows, and Linux.
 
 6. Change settings: 

--- a/mpy_xoss_sync.py
+++ b/mpy_xoss_sync.py
@@ -385,16 +385,24 @@ class BluetoothFileTransfer:
                     await self.fetch_file(fit_file)
 
     def extract_fit_filenames(self, file_path):
+        '''The list should be either a plain text (e.g. filelist.txt) or a JSON file.
+        '''
         fit_files = set()
-        pattern = re.compile(r'\d+\.fit')
 
         try:
             with open(file_path, 'r') as file:
-                lines = file.readlines()
-                for line in lines:
-                    match = pattern.search(line)
-                    if match:
-                        fit_files.add(match.group(0))
+                if not any((file_path.endswith(x) for x in ("json", "JSON"))):
+                    pattern = re.compile(r'\d+\.fit')
+                    lines = file.readlines()
+                    for line in lines:
+                        match = pattern.search(line)
+                        if match:
+                            fit_files.add(match.group(0))
+                else:
+                    import json
+                    json_dict = json.load(file)
+                    for x in json_dict['workouts']:
+                        fit_files.add(f'{x[0]}.fit')
         except Exception as e:
             print(f"Failed to read/parse file: {e}")
 

--- a/xoss_sync.py
+++ b/xoss_sync.py
@@ -18,7 +18,7 @@
 # 6. timings/delays were adjusted for my use case (XOSS G+, Win10 on Core-i5, TPLink UB400 BT dongle, py-3.8.6 and bleak-0.22.2).
 # 7. addition of send_file() to modify device settings via JSON file (e.g. Setting.json or settings.json).
 # 8. support for STX (1024-byte) block in YMODEM, though it's not well tested.
-# 9. support for parsing track list file in JSON fromat.
+# 9. support for parsing track list file in JSON format.
 #
 # TODO:
 # 1. handling of fit-file data more efficiently on memory.


### PR DESCRIPTION
Fixes issue #6
 Newer devices such as XOSS NAV and XOSS G+ 2nd Gen (aka G2+) use "workouts.json" as the list of FIT files instead of the plain text ("filelist.txt").  This PR implements a function to parse such JSON lists.